### PR TITLE
fix(snap): resolve validation error by removing icon from apps section

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,6 @@ architectures:
 apps:
   hasi:
     command: hasi
-    icon: gui/icon.png
     extensions: [gnome]
     plugs:
       - home


### PR DESCRIPTION
## Description
This PR fixes a validation error in the Snapcraft build process. The `icon` key is not permitted under the `apps` section for `core22` based snaps and caused the build to fail with a `pydantic_core._pydantic_core.ValidationError`.

The icon remains correctly configured through:
1. The `snap/gui/icon.png` file (standard for snap metadata).
2. The `.desktop` file integration which specifies the icon for the system menu.

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧰 Maintenance (chore, refactor, dependency updates, etc.)

## How Has This Been Tested?
- Verified the error message in GitHub Actions: `apps.hasi.icon Extra inputs are not permitted`.
- Verified the fix by aligning with Snapcraft core22 schema requirements.

## Checklist:
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] I have labeled the PR correctly for the changelog