### PR TITLE
fix: resolve snapcraft build error

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,7 +30,6 @@ architectures:
 apps:
   hasi:
     command: hasi
-    icon: gui/icon.png
     extensions: [gnome]
     plugs:
       - home


### PR DESCRIPTION
## Description
This PR syncs the latest fix from `develop` to `main`. 
Specifically, it removes the unsupported `icon` key from the `apps` section in `snapcraft.yaml`, which was causing validation failures in GitHub Actions.

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code