### PR TITLE
fix(snap): add retry logic to snap build and publish steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,11 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
       - name: Build Snap
-        uses: snapcore/action-build@v1
+        uses: W9jds/retry-action@v2
+        with:
+          action: snapcore/action-build@v1
+          attempt_limit: 3
+          attempt_delay: 20000
       - name: Upload Snap Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -164,9 +168,13 @@ jobs:
 
       - name: Publish to Snap Store
         if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
-        uses: snapcore/action-publish@v1
+        uses: W9jds/retry-action@v2
+        with:
+          action: snapcore/action-publish@v1
+          attempt_limit: 3
+          attempt_delay: 20000
+          with: |
+            snap: ${{ env.SNAP_FILE }}
+            release: ${{ startsWith(github.ref, 'refs/tags/v') && 'stable' || 'edge' }}
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
-        with:
-          snap: ${{ env.SNAP_FILE }}
-          release: ${{ startsWith(github.ref, 'refs/tags/v') && 'stable' || 'edge' }}


### PR DESCRIPTION
## Description
This PR adds retry logic to the Snapcraft build and publish steps in the GitHub Actions workflow. This is intended to handle transient errors such as LXC or network failures during the build process.

The retry mechanism uses `W9jds/retry-action@v2` with:
- `attempt_limit: 3`
- `attempt_delay: 20000` (20 seconds)

This will make the CI/CD pipeline more resilient to temporary environment issues.

## Type of change
- [x] 🧰 Maintenance (chore, refactor, dependency updates, etc.)

## How Has This Been Tested?
- Verified the workflow YAML syntax.
- The efficacy will be tested in the next CI run.

## Checklist:
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have labeled the PR correctly for the changelog