### PR TITLE
fix(snap): replace defunct retry-action and use direct shell commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,15 @@ jobs:
           cache: true
       - name: Install dependencies
         run: flutter pub get
+      - name: Install Snapcraft
+        run: sudo snap install snapcraft --classic
       - name: Build Snap
-        uses: W9jds/retry-action@v2
+        uses: nick-fields/retry@v3
         with:
-          action: snapcore/action-build@v1
-          attempt_limit: 3
-          attempt_delay: 20000
+          timeout_minutes: 20
+          max_attempts: 3
+          command: snapcraft pack
+          retry_on: error
       - name: Upload Snap Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -170,13 +173,14 @@ jobs:
 
       - name: Publish to Snap Store
         if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
-        uses: W9jds/retry-action@v2
+        uses: nick-fields/retry@v3
         with:
-          action: snapcore/action-publish@v1
-          attempt_limit: 3
-          attempt_delay: 20000
-          with: |
-            snap: ${{ env.SNAP_FILE }}
-            release: ${{ startsWith(github.ref, 'refs/tags/v') && 'stable' || 'edge' }}
+          timeout_minutes: 10
+          max_attempts: 3
+          command: |
+            SNAP_FILE=$(find release_files -name '*.snap' | head -n 1)
+            CHANNEL=${{ startsWith(github.ref, 'refs/tags/v') && 'stable' || 'edge' }}
+            snapcraft push $SNAP_FILE --release $CHANNEL
+          retry_on: error
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}


### PR DESCRIPTION
## Description
This PR fixes the 'repository not found' error in the CI workflow by replacing the defunct `w9jds/retry-action` with `nick-fields/retry@v3`.

To ensure maximum reliability and avoid issues with wrapping composite actions, the Snapcraft build and publish steps have been converted to direct shell commands:
- **Build**: Uses `snapcraft pack` within the retry logic.
- **Publish**: Uses `snapcraft push` within the retry logic.
- **Environment**: Added an explicit step to install `snapcraft` via snap to ensure availability in the runner.

This configuration handles transient LXC/network errors with 3 attempts and a reasonable timeout.

## Type of change
- [x] 🧰 Maintenance (chore, refactor, dependency updates, etc.)

## How Has This Been Tested?
- Verified workflow YAML syntax.
- The efficacy will be validated in the next CI run on `develop`.

## Checklist:
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code