### PR TITLE
fix(snap): implement robust shell building with sudo -E and destructive-mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           timeout_minutes: 20
           max_attempts: 3
-          command: snapcraft pack --destructive-mode
+          command: sudo -E snapcraft pack --destructive-mode
           retry_on: error
       - name: Upload Snap Artifact
         uses: actions/upload-artifact@v4
@@ -180,7 +180,7 @@ jobs:
           command: |
             SNAP_FILE=$(find release_files -name '*.snap' | head -n 1)
             CHANNEL=${{ startsWith(github.ref, 'refs/tags/v') && 'stable' || 'edge' }}
-            snapcraft push $SNAP_FILE --release $CHANNEL --destructive-mode
+            sudo -E snapcraft push $SNAP_FILE --release $CHANNEL --destructive-mode
           retry_on: error
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}


### PR DESCRIPTION
## Description
This Pull Request provides a robust solution for the Snapcraft build failures in the GitHub Actions environment.

### Key Enhancements:
- **Repository Structure**: Moved non-snapcraft configuration files (`README.md`, `CONTRIBUTING.md`, and build/validation scripts) from the `snap/` root to `snap/local/`. This resolves the 'unsupported paths' validation error for `core22` snaps.
- **Run with Sudo**: Updated Snapcraft `pack` and `push` commands to use `sudo -E`. This is required when using `--destructive-mode` to allow `snapcraft` to install the necessary `build-packages` via `apt`.
- **Preserved Environment**: The `-E` flag ensures that environment variables (crucially, the `SNAPCRAFT_STORE_CREDENTIALS`) are preserved when running under sudo.
- **Destructive Mode**: Explicitly using `--destructive-mode` to avoid the overhead and potential failures of launching LXD or Multipass containers within the ephemeral GitHub runner VM.

These changes ensure a reliable, repeatable, and fast Snap building process that is natively compatible with standard GitHub Actions runners.

## Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧰 Maintenance (chore, refactor, dependency updates, etc.)

## Checklist:
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] I have labeled the PR correctly for the changelog