### PR TITLE
chore: enable snap edge builds on develop branch merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
     tags:
       - 'v*'
   workflow_dispatch:
@@ -142,7 +143,7 @@ jobs:
   release:
     needs: [build-linux-snap, build-linux-appimage, build-windows]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v'))
     steps:
       - uses: actions/checkout@v4
       
@@ -172,7 +173,7 @@ jobs:
         run: echo "SNAP_FILE=$(find release_files -name '*.snap' | head -n 1)" >> $GITHUB_ENV
 
       - name: Publish to Snap Store
-        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main'
+        if: startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 10


### PR DESCRIPTION
## Description
This PR updates the release workflow to trigger on the `develop` branch. When changes are pushed to `develop`, a build will be created and the Snap package will be published to the `edge` channel.

### Changes:
- Added `develop` to the `push.branches` trigger.
- Updated the `release` job condition to include `develop`.
- Updated the `Publish to Snap Store` step condition to include `develop`.

## QA Steps
1. Merge this PR into `develop`.
2. Verify that the 'Build and Release' workflow starts.
3. Verify that the Snap package is successfully pushed to the `edge` channel.