### PR TITLE
fix(snap): resolution of libunistring error by pinning runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build-linux-snap:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,7 +24,10 @@ jobs:
           channel: 'stable'
           cache: true
       - name: Install dependencies
-        run: flutter pub get
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libblkid-dev liblzma-dev libnm-dev libsecret-1-dev libunistring-dev
+          flutter pub get
       - name: Install Snapcraft
         run: sudo snap install snapcraft --classic
       - name: Build Snap
@@ -41,7 +44,7 @@ jobs:
           path: '*.snap'
 
   build-linux-appimage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
@@ -52,7 +55,7 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libblkid-dev liblzma-dev libnm-dev libsecret-1-dev
+          sudo apt-get install -y libgtk-3-dev libblkid-dev liblzma-dev libnm-dev libsecret-1-dev libunistring-dev
       
       - name: Get dependencies
         run: flutter pub get

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,6 +74,8 @@ parts:
       - libsqlite3-dev
       - libavahi-client-dev
       - libavahi-common-dev
+      - libunistring-dev
+      - libnm-dev
     stage-packages:
       - libgtk-3-0
       - libgdk-pixbuf2.0-0
@@ -87,6 +89,7 @@ parts:
       - libpulse0
       - libsndfile1
       - libasound2
+      - libnm0
     override-build: |
       rm -rf build/
       craftctl default


### PR DESCRIPTION
## Changes
- Pin GitHub Actions runner to `ubuntu-22.04` for Snap and AppImage builds (matches `core22` base).
- Added `libunistring-dev` and `libnm-dev` to host installation steps and Snapcraft `build-packages`.
- Added `libnm0` to Snapcraft `stage-packages`.

## QA Steps
1. Verify the 'Build and Release' workflow triggers on push to this branch.
2. Confirm the `build-linux-snap` job completes successfully without the `libunistring.so.2` error.
3. Verify that the Snap artifact is correctly uploaded and published to the edge channel (if applicable).