### PR TITLE
fix: resolve localization build error

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,3 +1,4 @@
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
+synthetic-package: false

--- a/lib/screens/custom_widget_config_dialog.dart
+++ b/lib/screens/custom_widget_config_dialog.dart
@@ -191,7 +191,6 @@ class _CustomWidgetConfigDialogState extends State<CustomWidgetConfigDialog> {
   }
 
   Future<void> _pickImage() async {
-    final l10n = AppLocalizations.of(context)!;
     try {
       FilePickerResult? result = await FilePicker.platform.pickFiles(
         type: FileType.image,

--- a/lib/widgets/voice_assistant_widget.dart
+++ b/lib/widgets/voice_assistant_widget.dart
@@ -48,6 +48,7 @@ class _VoiceAssistantWidgetState extends State<VoiceAssistantWidget> {
     if (response != null) {
       _addMessage(response, false);
     } else {
+      if (!mounted) return;
       final l10n = AppLocalizations.of(context)!;
       _addMessage(l10n.assistCommandError, false);
     }


### PR DESCRIPTION
## Description
Resolves the 'flutter_gen' package resolution error by explicitly configuring synthetic-package generation to false in l10n.yaml. Also fixes minor analysis warnings.

## Changes
- [l10n.yaml] Add synthetic-package: false
- [custom_widget_config_dialog.dart] Remove unused variable
- [voice_assistant_widget.dart] Add mounted check

## QA Steps
1. Run `flutter clean && flutter pub get`
2. Run `flutter gen-l10n`
3. Run `flutter build linux --release --target lib/main.dart` and verify it succeeds.
4. Run `flutter analyze` and verify no issues.